### PR TITLE
Fix overlay center alignment for new jQuery version

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -134,8 +134,8 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
-					 oWidth = overlay.outerWidth({margin:true}),
-					 oHeight = overlay.outerHeight({margin:true}); 
+					 oWidth = overlay.outerWidth(true),
+					 oHeight = overlay.outerHeight(true);
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 


### PR DESCRIPTION
It breaks center alignment for `showModal` and other plugins using `jquery tools overlay`.

https://jira.brandwatch.com/browse/NRP-2625
