### PR TITLE
New request for an overlay to be displayed is not ignored while close animation is running

### DIFF
--- a/src/toolbox/toolbox.expose.js
+++ b/src/toolbox/toolbox.expose.js
@@ -62,15 +62,22 @@
 		if (fn) { return fn.call($.mask); }
 	}
 	
-	var mask, exposed, loaded, config, overlayIndex;		
+	var mask, exposed, loaded, config, overlayIndex,
+		closingNow = false;		
 	
 	
 	$.mask = {
 		
 		load: function(conf, els) {
 			
+			if (closingNow && mask) {
+				// this calls the fadeOut callback
+				// and sets closingNow to false
+				mask.finish();
+			}
+
 			// already loaded ?
-			if (loaded) { return this; }			
+			if (loaded) { return this; }
 			
 			// configuration
 			if (typeof conf == 'string') {
@@ -169,11 +176,13 @@
 				// onBeforeClose
 				if (call(config.onBeforeClose) === false) { return this; }
 					
+				closingNow = true;
 				mask.fadeOut(config.closeSpeed, function()  {					
 					call(config.onClose);					
 					if (exposed) {
 						exposed.css({zIndex: overlayIndex});						
-					}				
+					}
+					closingNow = false;				
 					loaded = false;
 				});				
 				


### PR DESCRIPTION
Previously, if a new call was made to the plugin and a previous overlay was still being closed with an animation, the new call was ignored. That means if we remove an overlay and immediately try to create a new one, we end up not having an overlay.

Now, if a new call comes while an old closing animation still runs, the animation is completed immediately, final CSS properties set, callbacks called, and new overlay is immediately created.
